### PR TITLE
Add support for Bolero (detect "blazor serve" and copy dll to dist)

### DIFF
--- a/src/FcsWatch.Binary/Extensions.fs
+++ b/src/FcsWatch.Binary/Extensions.fs
@@ -72,10 +72,21 @@ module Extensions =
 
             logger.CopyPdb configuration (Path.changeExtension ".pdb" originDll) (Path.changeExtension ".pdb" fileName)
 
+            destCrackedFsprojSingleTarget.AdditionalTargetDirs |> Seq.iter (fun targetDir ->
+                let destDll = targetDir </> fileName
+                logger.CopyFile originDll destDll
+                logger.CopyPdb configuration (Path.changeExtension ".pdb" originDll) (Path.changeExtension ".pdb" fileName))
+
+
         let copyObjToBin configuration (singleTargetCrackedFsproj: SingleTargetCrackedFsproj) =
             logger.CopyFile singleTargetCrackedFsproj.ObjTargetFile singleTargetCrackedFsproj.TargetPath
 
             logger.CopyPdb configuration singleTargetCrackedFsproj.ObjTargetPdb singleTargetCrackedFsproj.TargetPdbPath
+
+            singleTargetCrackedFsproj.AdditionalTargetDirs |> Seq.iter (fun targetDir ->
+                logger.CopyFile singleTargetCrackedFsproj.ObjTargetFile targetDir
+                logger.CopyPdb configuration singleTargetCrackedFsproj.ObjTargetPdb targetDir)
+
 
         let compile (checker: FSharpChecker) (crackedProjectSingleTarget: SingleTargetCrackedFsproj) = async {
             let tmpDll = crackedProjectSingleTarget.ObjTargetFile

--- a/src/FcsWatch.Core/CrackedFsProj.fs
+++ b/src/FcsWatch.Core/CrackedFsProj.fs
@@ -75,6 +75,12 @@ module CrackedFsproj =
 
         member x.TargetDir = Path.getDirectory x.TargetPath
 
+        member x.AdditionalTargetDirs =
+            x.Props |> Map.toSeq
+            |> Seq.choose (function
+                | "RunArguments", "blazor serve" -> Some(x.TargetDir </> "dist/_framework/_bin")
+                | _ -> None)
+
         member x.TargetFramework = x.Props.["TargetFramework"]
 
         member x.TargetPdbPath = Path.changeExtension ".pdb" x.TargetPath

--- a/src/FcsWatch.Core/ProjectCoreCracker.fs
+++ b/src/FcsWatch.Core/ProjectCoreCracker.fs
@@ -77,7 +77,7 @@ module ProjectCoreCracker =
 
       let getFscArgs = Dotnet.ProjInfo.Inspect.getFscArgs
       let getP2PRefs = Dotnet.ProjInfo.Inspect.getResolvedP2PRefs
-      let gp () = Dotnet.ProjInfo.Inspect.getProperties (["TargetPath"; "IsCrossTargetingBuild"; "TargetFrameworks"; "TargetFramework"])
+      let gp () = Dotnet.ProjInfo.Inspect.getProperties (["TargetPath"; "IsCrossTargetingBuild"; "TargetFrameworks"; "TargetFramework"; "RunArguments"])
 
       let results =
           let runCmd exePath args = runProcess projDir exePath (args |> String.concat " ")


### PR DESCRIPTION
Addresses #25 

Bolero/Blazor serves its `.dlls` from a `dist` folder. These changes detect blazor from the proj file, and appropriately copy file to this folder when needed. 

I can add tests tomorrow, but I would appreciate a review of the logic. 