### PR TITLE
Support watching additional content files

### DIFF
--- a/src/FcsWatch.Core/Types.fs
+++ b/src/FcsWatch.Core/Types.fs
@@ -11,6 +11,7 @@ open Fake.DotNet
 open System.Threading.Tasks
 open FSharp.Compiler.SourceCodeServices
 open Fake.IO.Globbing.Operators
+open FcsWatch.Core.ProjectCoreCracker
 
 type IMailboxProcessor<'Msg> =
     abstract member PostAndReply: buildMsg: (AsyncReplyChannel<'Reply> -> 'Msg) -> 'Reply
@@ -392,7 +393,7 @@ module FullCrackedFsproj =
             let fsharpProjectOptions =
                 { fsharpProjectOptions with 
                     OtherOptions = otherOptions
-                    SourceFiles = getSourceFilesFromOtherOptions otherOptions }
+                    SourceFiles = getSourceFilesFromOtherOptions otherOptions AdditionalProjInfoConfig.Empty "" }
 
             return noframwork fsharpProjectOptions builder.File
 

--- a/tests/FcsWatch.Tests/Tests.fs
+++ b/tests/FcsWatch.Tests/Tests.fs
@@ -34,6 +34,8 @@ let testSourceFileAdded = datas </> @"TestLib2/Added.fs"
 
 let testSourceFile1InTestLib = datas </> @"TestLib1/Library.fs"
 
+let testContentFile = datas </> @"TestProject/Content.html"
+
 let expectCompilerNumber excepted (CompilerNumber compilerNumber) =
     Expect.equal excepted compilerNumber (sprintf "expected compiler number %d,while current compiler number is %d" excepted compilerNumber)
 
@@ -93,6 +95,10 @@ let programTests =
 
             finally
                 Fsproj.removeFileFromProject "Added.fs" testProjPath
+
+        testCase "change html content file in TestProject will trigger compiling" <| fun _ ->
+            /// TestProject/Content.html
+            testSourceFilesChanged watcher [testContentFile] 1
     ]
 
 

--- a/tests/datas/TestProject/Content.html
+++ b/tests/datas/TestProject/Content.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/datas/TestProject/TestProject.fsproj
+++ b/tests/datas/TestProject/TestProject.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.2; net462</TargetFrameworks>
@@ -16,7 +16,12 @@
     <Compile Include="Test2.fs" />
     <Compile Include="Test.fs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Content.html" />
+  </ItemGroup>
+  <ItemGroup>
+    <Watch Include="*.html" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Adds support for watching additional files.
fixes: #35 

It would be better to use ProjInfo for this, however it does not support surfacing these files yet.

Related: https://github.com/enricosada/dotnet-proj-info/issues/53#issue-446325848

I will add tests, wanted your opinion on implementation @humhei 